### PR TITLE
Add MkDocs GitHub Pages deployment workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,31 @@
+# .github/workflows/docs.yml
+name: Deploy Docs
+
+on:
+  push:
+    branches:
+      - work
+  pull_request:
+    branches:
+      - work
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+
+      - name: Install dependencies
+        run: |
+          pip install mkdocs mkdocs-material
+
+      - name: Deploy to GitHub Pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mkdocs gh-deploy --force

--- a/README.md
+++ b/README.md
@@ -1,2 +1,10 @@
 # CPP-Interview
 c++面试(主要聚焦于新的c++版本)
+
+## Documentation
+
+This repository uses [MkDocs](https://www.mkdocs.org/) with the Material theme. Documentation is automatically built and deployed to the `gh-pages` branch whenever changes are pushed to the `work` branch. To preview the docs locally, run:
+
+```bash
+mkdocs serve
+```


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to build and deploy MkDocs site
- document automated MkDocs workflow in README

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68be44a7f9d88331bdb62c81d956160c