### PR TITLE
Switch documentation to Read the Docs theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 ## Documentation
 
-This repository uses [MkDocs](https://www.mkdocs.org/) with the Material theme. Documentation is automatically built and deployed to the `gh-pages` branch whenever changes are pushed to the `work` branch. To preview the docs locally, run:
+This repository uses [MkDocs](https://www.mkdocs.org/) with the Read the Docs theme. Documentation is automatically built and deployed to the `gh-pages` branch whenever changes are pushed to the `work` branch. To preview the docs locally, run:
 
 ```bash
 mkdocs serve

--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,12 @@
+/* Increase content area width for larger tables/charts */
+.wy-nav-content {
+    /* Allow the content to stretch to the browser width */
+    max-width: 100%;
+}
+
+@media (min-width: 1800px) {
+    /* On very wide screens cap the width so lines don't become too long */
+    .wy-nav-content {
+        max-width: 1800px;
+    }
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -7,4 +7,7 @@ nav:
   - C++14: cpp14.md
   - C++17: cpp17.md
 theme:
-  name: material
+  name: readthedocs
+
+extra_css:
+  - stylesheets/extra.css


### PR DESCRIPTION
## Summary
- use Read the Docs styling for documentation
- widen content area with custom CSS

## Testing
- `mkdocs build`

------
https://chatgpt.com/codex/tasks/task_e_68be497b8d08833197eb6444bedc4804