### PR TITLE
docs: clarify dynamic_cast polymorphic requirement

### DIFF
--- a/docs/type_conversion.md
+++ b/docs/type_conversion.md
@@ -109,7 +109,7 @@ try {
 }
 ```
 
-> `dynamic_cast` 依赖多态类型的 RTTI，仅适用于带虚函数的类。
+> `dynamic_cast` 依赖多态类型的 RTTI，仅适用于带虚函数的类；若类中没有虚函数，使用 `dynamic_cast` 会在编译期报错。
 
 ## `const_cast`
 


### PR DESCRIPTION
## Summary
- explain that `dynamic_cast` requires polymorphic classes; without virtual functions it fails to compile

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c0dbbbdf9c8331ba64613d22d995aa