### PR TITLE
Improve docs theme and layout

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,12 +1,10 @@
-/* Increase content area width for larger tables/charts */
-.wy-nav-content {
-    /* Allow the content to stretch to the browser width */
-    max-width: 100%;
+/* Custom styles for Material theme */
+.md-grid {
+    /* Expand content width for better readability */
+    max-width: 1200px;
 }
 
-@media (min-width: 1800px) {
-    /* On very wide screens cap the width so lines don't become too long */
-    .wy-nav-content {
-        max-width: 1800px;
-    }
+body {
+    /* Use a clean, cross-platform font stack */
+    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans", sans-serif;
 }

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,24 @@
 site_name: CPP-Interview
 site_url: https://SwartzMss.github.io/CPP-Interview/
 site_description: C++ 面试
+theme:
+  name: material
+  palette:
+    - scheme: default
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-night
+        name: 切换到夜间模式
+    - scheme: slate
+      primary: indigo
+      accent: indigo
+      toggle:
+        icon: material/weather-sunny
+        name: 切换到日间模式
+  features:
+    - navigation.top
+    - content.code.copy
 nav:
   - 首页: index.md
   - STL:


### PR DESCRIPTION
## Summary
- switch documentation to Material theme with light/dark toggle
- widen content and use cleaner font stack for better readability

## Testing
- `mkdocs build`


------
https://chatgpt.com/codex/tasks/task_e_68c0f19203e0833184ec27007c3794d8